### PR TITLE
Extend auto-reload tests

### DIFF
--- a/src/test/java/org/mdcfg/AutoUpdateTest.java
+++ b/src/test/java/org/mdcfg/AutoUpdateTest.java
@@ -10,6 +10,7 @@ import org.mdcfg.builder.MdcBuilder;
 import org.mdcfg.builder.MdcCallback;
 import org.mdcfg.exceptions.MdcException;
 import org.mdcfg.provider.MdcProvider;
+import org.mdcfg.helpers.TestContextBuilder;
 
 import java.io.*;
 import java.nio.file.Files;
@@ -40,6 +41,8 @@ public class AutoUpdateTest {
 
         String count = future.get();
         assertEquals(1, Integer.parseInt(count));
+        assertEquals("43000", provider.getString(TestContextBuilder.init().model("ford").build(), "price"));
+        assertEquals(1, provider.getSize());
     }
 
     @Test
@@ -58,6 +61,8 @@ public class AutoUpdateTest {
 
         String count = future.get();
         assertEquals(1, Integer.parseInt(count));
+        assertEquals("43000", provider.getString(TestContextBuilder.init().model("ford").build(), "price"));
+        assertEquals(1, provider.getSize());
     }
 
     private void modifyFile(Path from, Path to) {


### PR DESCRIPTION
## Summary
- enhance AutoUpdateTest to validate values after reload

## Testing
- `mvn -Dtest=AutoUpdateTest test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eb3eba1108323998957a1dcf0f2ab