### PR TITLE
Fix README example snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,20 +58,18 @@ Add the following code to your application that loads configuration:
 public class MdcfgPoweredApplication {
   public static void main(String... args) {
       // load config
-      MDCConfig config = MDCConfig.builder()
-              .source("config.yaml")
-              .build();
-      
+      MdcProvider provider = MdcBuilder.withYaml("config.yaml").build();
+
       // Define a context for the configuration
       MdcContext context = new MdcContext();
-      context.put("environment", "production");
+      context.put("env", "production");
       context.put("region", "us-west");
 
       // Retrieve a configuration value using the context
-      String databaseUrl = config.getString(context, "database.url");
-      String databaseUsername = config.getString(context, "database.username");
-      String databasePassword = config.getString(context, "database.password");
-      int maxConnections = config.getInt(context, "database.maxConnections");
+      String databaseUrl = provider.getString(context, "database.url");
+      String databaseUsername = provider.getString(context, "database.username");
+      String databasePassword = provider.getString(context, "database.password");
+      int maxConnections = provider.getInt(context, "database.maxConnections");
 
       // use it
   }


### PR DESCRIPTION
## Summary
- update README example to use `MdcProvider` and context keys `env` and `region`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec97ef9788323bcfc497532af79c5