### PR TITLE
Refactor Chain engine to avoid regex

### DIFF
--- a/src/main/java/org/mdcfg/model/Property.java
+++ b/src/main/java/org/mdcfg/model/Property.java
@@ -72,58 +72,18 @@ public class Property {
         return result;
     }
 
-    /** create compare string using (plitBy@plitValue as replacement for List based context dimension)
-     * and match it on active chains by down to up priority */
+    /** Check chains by down to up priority */
     private String getString(MdcContext context, List<Chain> activeChains, String splitBy, Object splitValue, boolean isCaseSensitive) {
-        String compare = createCompareString(context, splitBy, splitValue);
-        compare = isCaseSensitive ? compare : compare.toLowerCase(Locale.ROOT);
+        if(splitBy != null){
+            context = new MdcContext() {{ putAll(context); put(splitBy, List.of(splitValue)); }};
+        }
         for (Chain chain : activeChains) {
-            if(chain.match(context, compare)){
+            if(chain.match(context, isCaseSensitive)){
                 return chain.getValue();
             }
         }
         return null;
     }
 
-    /**
-     * Create compare string by dimensions order.
-     * <p> For example for property:
-     *  <pre>
-     *    horsepower:
-     *      any@: 400
-     *      model@bmw:
-     *        drive@4WD: 500
-     *  </pre>
-     *  Context:
-     *  <pre>
-     *   model = bmw
-     *   drive = 4WD
-     *  </pre>
-     *  Compare string will be {@code model@bmw.drive@4WD}
-     */
-    private String createCompareString(Map<String, Object> context, String overrideName, Object overrideValue) {
-        StringBuilder compare = new StringBuilder();
-        for (Dimension dimension : dimensions.values()) {
-            if(compare.length() > 0){
-                compare.append(".");
-            }
-            compare.append(dimension.getName());
-            compare.append("@");
 
-            Object object;
-            if(dimension.getName().equals(overrideName)) {
-                object = "[" + overrideValue + "]";
-            } else {
-                object = context.getOrDefault(dimension.getName(), null);
-                if (object != null) {
-                    List<?> list = ProviderUtils.toList(object);
-                    if (list != null) {
-                        object = "[" + StringUtils.join(list, UNIT_SEPARATOR) + "]";
-                    }
-                }
-            }
-            compare.append(object);
-        }
-        return compare.toString();
-    }
 }

--- a/src/main/java/org/mdcfg/processor/PropertyProcessor.java
+++ b/src/main/java/org/mdcfg/processor/PropertyProcessor.java
@@ -12,7 +12,6 @@ import org.mdcfg.model.*;
 
 import java.util.*;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /** Parse data of one property and create {@link Property} object. */
 public class PropertyProcessor {
@@ -26,7 +25,6 @@ public class PropertyProcessor {
     private static final Pattern COMMA_PATTERN = Pattern.compile(",");
     private static final Pattern REFERENCE_PATTERN = Pattern.compile("\\$\\{[^}]+}");
     private static final char UNIT_SEPARATOR = (char) 31;
-    private static final String LIST_EXPRESSION = "\\[(.*" + UNIT_SEPARATOR + ")*%s(" + UNIT_SEPARATOR + ".*)*\\]";
     private final String name;
     private final Map<String, Dimension> dimensions = new HashMap<>();
     private final List<Chain> chains = new ArrayList<>();
@@ -137,44 +135,30 @@ public class PropertyProcessor {
      *  </ul>
      */
     private void createChain(Map<String, String> selectors, String value) {
-        StringBuilder plusBuilder = new StringBuilder();
-        StringBuilder minusBuilder = new StringBuilder();
-        boolean negativeUsed = false;
+        Map<String, Chain.SelectorData> plusSelectors = new LinkedHashMap<>();
+        Map<String, Chain.SelectorData> minusSelectors = new LinkedHashMap<>();
         List<Range> ranges = new ArrayList<>();
         List<Dimension> nonEmptyListDimensions = new ArrayList<>();
-        for ( Dimension dimension : dimensions.values()) {
-            if(plusBuilder.length() > 0){
-                plusBuilder.append("\\.");
-            }
-            if(minusBuilder.length() > 0){
-                minusBuilder.append("\\.");
-            }
+
+        for (Dimension dimension : dimensions.values()) {
             String dimensionKey = dimension.getName() + (dimension.isList() ? LIST_SIGN : "");
             if(selectors.containsKey(dimensionKey)) {
                 String selector = selectors.get(dimensionKey);
                 boolean negative = selector.startsWith(NEGATIVE_SELECTOR);
                 if(negative) {
-                    negativeUsed = true;
-                    // remove "!" from selector
                     selector = selector.substring(NEGATIVE_SELECTOR.length());
-                    applySelector(selector, minusBuilder, ranges, dimension, true);
-                    plusBuilder.append(dimension.getName()).append("@.*");
+                }
+                Chain.SelectorData data = parseSelectorData(selector, dimension, ranges, negative);
+                if(negative) {
+                    minusSelectors.put(dimension.getName(), data);
                 } else {
-                    applySelector(selector, plusBuilder, ranges, dimension, false);
-                    minusBuilder.append(dimension.getName()).append("@.*");
+                    plusSelectors.put(dimension.getName(), data);
                 }
                 if(dimension.isList()) {
                     nonEmptyListDimensions.add(dimension);
                 }
-            } else {
-                // any
-                plusBuilder.append(dimension.getName()).append("@.*");
-                minusBuilder.append(dimension.getName()).append("@.*");
             }
         }
-        // end
-        plusBuilder.append("$");
-        minusBuilder.append("$");
 
         if (null != loadHooks) {
             for (var hook : loadHooks) {
@@ -186,38 +170,11 @@ public class PropertyProcessor {
             hasReference = REFERENCE_PATTERN.matcher(value).find();
         }
 
-        Pattern positivePattern = Pattern.compile(plusBuilder.toString());
-        Pattern negativePattern = negativeUsed ? Pattern.compile(minusBuilder.toString()) : null;
-        Chain chain = new Chain(positivePattern, negativePattern, value, ranges);
+        Chain chain = new Chain(plusSelectors, minusSelectors, value, ranges);
         chains.add(0, chain);
         addListableChains(nonEmptyListDimensions, chain);
     }
 
-    /** Append pattern for one selector and add {@link Range} objects if needed. */
-    private void applySelector(String selector, StringBuilder pattern, List<Range> ranges, Dimension dimension, boolean negative) {
-        if (selector.contains(RANGE_SIGN)) {
-            selector = LIST_SIGN_PATTERN.matcher(selector).replaceAll("");
-            for (String selectorPart : COMMA_PATTERN.split(selector)) {
-                ranges.add(createRange(selectorPart, dimension, negative));
-            }
-            selector = "-?(?:\\d|,|\\s|\\.)*";
-        } else if (LIST_SIGN_PATTERN.matcher(selector).find()) {
-            // selector lists
-            selector = LIST_SIGN_PATTERN.matcher(selector).replaceAll("");
-            selector = Arrays.stream(COMMA_PATTERN.split(selector))
-                    .map(Pattern::quote)
-                    .collect(Collectors.joining("|", "(", ")"));
-        } else {
-            selector = Pattern.quote(selector);
-        }
-
-        // dimension list
-        if (dimension.isList()) {
-            selector = String.format(LIST_EXPRESSION, selector);
-        }
-
-        pattern.append(dimension.getName()).append("@").append(selector);
-    }
 
     /** Return iterator in reverse order */
     private ListIterator<Map.Entry<String, String>> reverseIterator(Map<String, String> map) {
@@ -251,6 +208,30 @@ public class PropertyProcessor {
             }
         }
         return new Range(dimension, minInclusive, min, maxInclusive, max, negative);
+    }
+
+    /** Parse selector string into {@link Chain.SelectorData} */
+    private Chain.SelectorData parseSelectorData(String selector, Dimension dimension, List<Range> ranges, boolean negative){
+        if(selector.contains(RANGE_SIGN)) {
+            selector = selector.replace("[", "").replace("]", "").replace(" ", "");
+            for(String part : selector.split(",")) {
+                if(!part.isBlank()) {
+                    ranges.add(createRange(part, dimension, negative));
+                }
+            }
+            return new Chain.SelectorData(dimension.isList(), List.of(), true);
+        }
+
+        selector = selector.replace("[", "").replace("]", "");
+        List<String> values = new ArrayList<>();
+        for(String part : selector.split(",")) {
+            String val = part.trim();
+            if(!val.isEmpty()) {
+                values.add(val);
+            }
+        }
+        boolean any = values.isEmpty();
+        return new Chain.SelectorData(dimension.isList(), values, any);
     }
 
 


### PR DESCRIPTION
## Summary
- drop Pattern matching from `Chain`
- adjust `Property` to use context directly
- construct selector data in `PropertyProcessor`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee3ab97588323b2687b5d0a155ca5