### PR TITLE
Add Range.matches coverage test

### DIFF
--- a/src/test/java/org/mdcfg/ProviderTest.java
+++ b/src/test/java/org/mdcfg/ProviderTest.java
@@ -13,6 +13,8 @@ import org.mdcfg.helpers.*;
 import org.mdcfg.provider.MdcContext;
 import org.mdcfg.provider.MdcConverter;
 import org.mdcfg.provider.MdcProvider;
+import org.mdcfg.model.Dimension;
+import org.mdcfg.model.Range;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -434,6 +436,14 @@ public class ProviderTest {
         assertEquals(Short.valueOf("6"), provider.getScalar(ctx, "engine.block.cylinder-count", Short.class));
         assertTrue(provider.getScalar(TestContextBuilder.init().clearance(20.0).build(), "off-road", boolean.class));
         assertTrue(provider.getScalar(TestContextBuilder.init().clearance(20.0).build(), "off-road", Boolean.class));
+    }
+
+    @Test
+    public void testRangeMatchesDimensionNotPresent() {
+        Dimension dimension = new Dimension("clearance", true, false, true);
+        Range range = new Range(dimension, true, "0", true, "10");
+        MdcContext context = new MdcContext();
+        assertFalse(range.matches(context));
     }
 
     private static void assertListPOJO(List<?> list) {


### PR DESCRIPTION
## Summary
- add imports for new range test
- test Range.matches when context is missing dimension

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685028f74ce883239bb2f9e7e670daca